### PR TITLE
Dracut Testsuite changes for Tumbleweed

### DIFF
--- a/lib/dracut_testsuite_test.pm
+++ b/lib/dracut_testsuite_test.pm
@@ -66,19 +66,28 @@ sub testsuiteinstall {
 
     if (check_var('DISTRI', 'sle-micro')) {
         trup_shell 'zypper --gpg-auto-import-keys ref';
-        trup_shell 'zypper --non-interactive in dracut-kiwi-overlay python3-kiwi git tree dracut-kiwi-live NetworkManager nfs-kernel-server dhcp-server tcpdump open-iscsi iscsiuio tgt pciutils sysvinit-tools nbd';
+        trup_shell 'zypper --non-interactive in dracut-kiwi-overlay python3-kiwi git tree dracut-kiwi-live NetworkManager nfs-kernel-server dhcp-server dhcp-client tcpdump open-iscsi iscsiuio tgt pciutils sysvinit-tools nbd';
         # use dracut from the repo of the qa package
         if ($from_repo) {
-            trup_shell "zypper --non-interactive in --force $from_repo dracut dracut-mkinitrd-deprecated dracut-qa-testsuite";
+            if (is_tumbleweed) {
+                trup_shell "zypper --non-interactive in --force $from_repo dracut dracut-qa-testsuite";
+            } else {
+                trup_shell "zypper --non-interactive in --force $from_repo dracut dracut-mkinitrd-deprecated dracut-qa-testsuite";
+            }
 	} else {
             trup_shell 'zypper --non-interactive in dracut-qa-testsuite';
         }
     } else {
         zypper_call "--gpg-auto-import-keys ref";
-        zypper_call 'in dracut-kiwi-overlay python3-kiwi git tree dracut-kiwi-live NetworkManager nfs-kernel-server dhcp-server tcpdump open-iscsi iscsiuio tgt nbd';
+        zypper_call 'in dracut-kiwi-overlay python3-kiwi git tree dracut-kiwi-live NetworkManager nfs-kernel-server dhcp-server dhcp-client tcpdump open-iscsi iscsiuio tgt nbd';
         # use dracut from the repo of the qa package
         if ($from_repo) {
-            zypper_call "in --force $from_repo dracut dracut-mkinitrd-deprecated dracut-qa-testsuite";
+            if (is_tumbleweed) {
+                zypper_call "in --force $from_repo dracut dracut-qa-testsuite";
+            } else {
+                zypper_call "in --force $from_repo dracut dracut-mkinitrd-deprecated dracut-qa-testsuite";
+            }
+
 	} else {
             zypper_call "in dracut-qa-testsuite";
         }

--- a/schedule/qam/common/mau-dracut.yaml
+++ b/schedule/qam/common/mau-dracut.yaml
@@ -17,15 +17,15 @@ schedule:
 # - dracut_testsuite/test_16_dmsquash
 - dracut_testsuite/test_17_lvm_thin
 - dracut_testsuite/test_20_nfs
-- dracut_testsuite/test_21_nfs_nm
+# dracut_testsuite/test_21_nfs_nm
 - dracut_testsuite/test_30_iscsi
-- dracut_testsuite/test_31_iscsi_nm
+# dracut_testsuite/test_31_iscsi_nm
 - dracut_testsuite/test_35_iscsi_multi
-- dracut_testsuite/test_36_iscsi_multi_nm
+# dracut_testsuite/test_36_iscsi_multi_nm
 # - dracut_testsuite/test_40_nbd
 # - dracut_testsuite/test_41_nbd_nm
 - dracut_testsuite/test_50_multinic
-- dracut_testsuite/test_51_multinic_nm
+# dracut_testsuite/test_51_multinic_nm
 - dracut_testsuite/test_60_bondbridgevlanifcfg
 # - dracut_testsuite/test_61_bondbridgevlanifcfg_nm
 - dracut_testsuite/test_62_skipcpio


### PR DESCRIPTION
This excludes the NetworkManager tests, drops the dracut-mkinitrd-deprecated package and adds the dhcp-client package for the testsuite run